### PR TITLE
Improve frontend layout with dark mode

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,7 +11,7 @@
       rel="stylesheet"
     />
   </head>
-  <body class="bg-gray-50 text-gray-900">
+  <body class="bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,7 +40,7 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
 
 function App() {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       <QueryErrorResetBoundary>
         {({ reset }) => (
           <ErrorBoundary

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Outlet, Link, useLocation } from 'react-router-dom';
 import useAuth from '../hooks/useAuth';
 import useWebSocket from '../hooks/useWebSocket';
+import ThemeToggle from './ThemeToggle';
 
 // Icons (using inline SVGs for better control)
 const Icons = {
@@ -81,10 +82,10 @@ export default function Layout() {
   useWebSocket();
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       {/* Sidebar for desktop */}
       <div className="hidden lg:flex lg:flex-shrink-0">
-        <div className="flex flex-col w-64 border-r border-gray-200 bg-white">
+        <div className="flex flex-col w-64 border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
           <div className="flex-1 flex flex-col pt-5 pb-4 overflow-y-auto">
             <div className="flex items-center flex-shrink-0 px-4">
               <h1 className="text-xl font-semibold text-gray-900">Zerodha MCP</h1>
@@ -98,15 +99,19 @@ export default function Layout() {
                     to={item.href}
                     className={classNames(
                       isActive
-                        ? 'bg-gray-100 text-blue-600'
-                        : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900',
+                        ? 'bg-gray-100 dark:bg-gray-700/50 text-blue-600 ring-2 ring-cyan-400/60'
+                        : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white',
                       'group flex items-center px-3 py-2.5 text-sm font-medium rounded-md transition-colors duration-150'
                     )}
                   >
-                    <span className={classNames(
-                      isActive ? 'text-blue-500' : 'text-gray-400 group-hover:text-gray-500',
-                      'mr-3 flex-shrink-0 h-5 w-5'
-                    )}>
+                    <span
+                      className={classNames(
+                        isActive
+                          ? 'text-blue-500'
+                          : 'text-gray-400 dark:text-gray-500 group-hover:text-gray-500 dark:group-hover:text-gray-400',
+                        'mr-3 flex-shrink-0 h-5 w-5'
+                      )}
+                    >
                       {Icons[item.icon as keyof typeof Icons]}
                     </span>
                     {item.name}
@@ -115,7 +120,8 @@ export default function Layout() {
               })}
             </nav>
           </div>
-          <div className="flex-shrink-0 flex border-t border-gray-200 p-4">
+          <div className="flex-shrink-0 flex items-center justify-between gap-2 border-t border-gray-200 p-4">
+            <ThemeToggle />
             <button
               onClick={logout}
               className="group flex w-full items-center px-3 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900 rounded-md transition-colors duration-150"
@@ -142,7 +148,7 @@ export default function Layout() {
           )}
           {/* Sidebar */}
           <div
-            className={`fixed inset-y-0 left-0 w-72 bg-white shadow-xl transform ${
+            className={`fixed inset-y-0 left-0 w-72 bg-white dark:bg-gray-800 shadow-xl transform ${
               sidebarOpen ? 'translate-x-0' : '-translate-x-full'
             } transition-transform duration-300 ease-in-out`}
           >
@@ -170,16 +176,20 @@ export default function Layout() {
                         to={item.href}
                         className={classNames(
                           isActive
-                            ? 'bg-blue-50 text-blue-600'
-                            : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900',
+                            ? 'bg-blue-50 dark:bg-gray-700/50 text-blue-600 ring-2 ring-cyan-400/60'
+                            : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white',
                           'group flex items-center px-3 py-2.5 text-sm font-medium rounded-lg mx-1 transition-colors duration-150'
                         )}
                         onClick={() => setSidebarOpen(false)}
                       >
-                        <span className={classNames(
-                          isActive ? 'text-blue-500' : 'text-gray-400 group-hover:text-gray-500',
-                          'mr-3 flex-shrink-0 h-5 w-5'
-                        )}>
+                        <span
+                          className={classNames(
+                            isActive
+                              ? 'text-blue-500'
+                              : 'text-gray-400 dark:text-gray-500 group-hover:text-gray-500 dark:group-hover:text-gray-400',
+                            'mr-3 flex-shrink-0 h-5 w-5'
+                          )}
+                        >
                           {Icons[item.icon as keyof typeof Icons]}
                         </span>
                         {item.name}
@@ -189,7 +199,8 @@ export default function Layout() {
                 </div>
               </nav>
               {/* Footer */}
-              <div className="border-t border-gray-100 p-4">
+              <div className="border-t border-gray-100 p-4 flex items-center justify-between gap-2">
+                <ThemeToggle />
                 <button
                   onClick={logout}
                   className="group flex w-full items-center rounded-lg p-2 text-sm font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900 transition-colors duration-150"
@@ -206,25 +217,26 @@ export default function Layout() {
       </div>
 
       {/* Mobile header */}
-      <div className="lg:hidden sticky top-0 z-30 flex h-16 items-center bg-white px-4 shadow-sm">
+      <div className="lg:hidden sticky top-0 z-30 flex h-16 items-center bg-white dark:bg-gray-800 px-4 shadow-sm">
         <button
           type="button"
-          className="inline-flex items-center justify-center rounded-md p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-600"
+          className="inline-flex items-center justify-center rounded-md p-2 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-600"
           onClick={() => setSidebarOpen(true)}
         >
           <span className="sr-only">Open sidebar</span>
           {Icons.menu}
         </button>
-        <h1 className="ml-4 text-lg font-semibold text-gray-900">
+        <h1 className="ml-4 text-lg font-semibold text-gray-900 dark:text-gray-100 flex-1">
           {navigation.find((item) => item.href === location.pathname)?.name || 'Dashboard'}
         </h1>
+        <ThemeToggle />
       </div>
 
       {/* Main content */}
       <div className="lg:pl-64 flex flex-col flex-1">
         <div className="py-6">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 md:px-8">
-            <h1 className="text-2xl font-semibold text-gray-900">
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
               {navigation.find((item) => item.href === location.pathname)?.name || 'Dashboard'}
             </h1>
           </div>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useTheme } from '../hooks/useTheme';
+import { Icons } from './ui/Icons';
+
+const ThemeToggle: React.FC = () => {
+  const { theme, toggle } = useTheme();
+  return (
+    <button
+      onClick={toggle}
+      className="rounded-md p-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+      aria-label="Toggle theme"
+    >
+      {theme === 'dark' ? (
+        <Icons.sun className="w-5 h-5 text-yellow-300" />
+      ) : (
+        <Icons.moon className="w-5 h-5 text-blue-500" />
+      )}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/src/components/ui/Icons.tsx
+++ b/frontend/src/components/ui/Icons.tsx
@@ -29,6 +29,43 @@ export const Icons = {
       <path d="M21 12a9 9 0 1 1-6.219-8.56" />
     </svg>
   ),
+
+  // Sun icon
+  sun: (props: SVGProps<SVGSVGElement>) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <circle cx="12" cy="12" r="5" />
+      <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+    </svg>
+  ),
+
+  // Moon icon
+  moon: (props: SVGProps<SVGSVGElement>) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+    </svg>
+  ),
   
   // Key (login)
   key: (props: SVGProps<SVGSVGElement>) => (

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextProps {
+  theme: Theme;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextProps>({
+  theme: 'light',
+  toggle: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'light';
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') return stored as Theme;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') root.classList.add('dark');
+    else root.classList.remove('dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggle = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+
+  return <ThemeContext.Provider value={{ theme, toggle }}>{children}</ThemeContext.Provider>;
+};
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -197,6 +197,17 @@ input:focus, textarea:focus, select:focus {
 }
 
 /* Dark mode support */
+.dark {
+  --background: #1a1a1a;
+  --surface: #2c2c2e;
+  --text-primary: #f5f5f7;
+  --text-secondary: #a1a1a6;
+  --border: #3a3a3c;
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+
+/* Dark mode support */
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #1a1a1a;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { Toaster } from 'react-hot-toast';
 import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';
 import './index.css';
+import { ThemeProvider } from './hooks/useTheme';
 
 // Create a client for React Query
 const queryClient = new QueryClient({
@@ -19,11 +20,13 @@ const queryClient = new QueryClient({
 // Render the app
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <Router>
-        <App />
-        <Toaster position="top-right" />
-      </Router>
-    </QueryClientProvider>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <App />
+          <Toaster position="top-right" />
+        </Router>
+      </QueryClientProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- allow toggling dark mode using context hook
- add sun and moon icons
- wire ThemeProvider into React root
- update layout styling and navigation highlighting
- apply dark classes to base components

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852bf98532083308c49d3546e95b524