### PR TITLE
Fix backend imports

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -5,9 +5,9 @@ import morgan from 'morgan';
 import rateLimit from 'express-rate-limit';
 import { StatusCodes } from 'http-status-codes';
 import { config } from './config/index.js';
-import { requestLogger, logger } from './utils/logger';
-import apiRoutes from './routes/api';
-import { mcpService } from './services/mcpService';
+import logger, { requestLogger } from './utils/logger.js';
+import apiRoutes from './routes/api.js';
+import mcpService from './services/mcpService.js';
 
 export function createApp() {
   const app = express();
@@ -79,4 +79,4 @@ export function createApp() {
   return app;
 }
 
-export default createApp();
+export default createApp;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,8 +1,8 @@
 import { createServer } from 'http';
 import { config } from './config/index.js';
 import { mcpService, initWebSocketService } from './services/index.js';
-import createApp from './app';
-import logger from './utils/logger';
+import createApp from './app.js';
+import logger from './utils/logger.js';
 
 // Create Express app
 const app = createApp();

--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -1,8 +1,8 @@
 import { Router } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { v4 as uuidv4 } from 'uuid';
-import { mcpService } from '../services/mcpService';
-import logger from '../utils/logger';
+import mcpService from '../services/mcpService.js';
+import logger from '../utils/logger.js';
 
 const router = Router();
 

--- a/backend/src/services/index.js
+++ b/backend/src/services/index.js
@@ -1,4 +1,6 @@
-import * as mcpService from './mcpService';
-import * as webSocketService from './webSocketService';
-
-export { mcpService, webSocketService };
+export { default as mcpService } from './mcpService.js';
+export {
+  initWebSocketService,
+  getWebSocketService,
+  default as webSocketService,
+} from './webSocketService.js';

--- a/backend/src/services/mcpService.js
+++ b/backend/src/services/mcpService.js
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events';
 import RingBuffer from 'ringbufferjs';
 import { v4 as uuidv4 } from 'uuid';
 import { config } from '../config/index.js';
-import logger from '../utils/logger';
+import logger from '../utils/logger.js';
 
 class MCPService extends EventEmitter {
   constructor() {

--- a/backend/src/services/webSocketService.js
+++ b/backend/src/services/webSocketService.js
@@ -1,8 +1,8 @@
 import { WebSocketServer } from 'ws';
 import { v4 as uuidv4 } from 'uuid';
 import { config } from '../config/index.js';
-import logger from '../utils/logger';
-import { mcpService } from './mcpService';
+import logger from '../utils/logger.js';
+import mcpService from './mcpService.js';
 
 class WebSocketService {
   constructor(server) {
@@ -148,20 +148,23 @@ class WebSocketService {
   }
 }
 
-let webSocketService = null;
+let webSocketServiceInstance = null;
 
 export function initWebSocketService(server) {
-  if (!webSocketService) {
-    webSocketService = new WebSocketService(server);
+  if (!webSocketServiceInstance) {
+    webSocketServiceInstance = new WebSocketService(server);
   }
-  return webSocketService;
+  return webSocketServiceInstance;
 }
 
 export function getWebSocketService() {
-  if (!webSocketService) {
+  if (!webSocketServiceInstance) {
     throw new Error('WebSocketService not initialized');
   }
-  return webSocketService;
+  return webSocketServiceInstance;
 }
 
-export default webSocketService;
+export default {
+  initWebSocketService,
+  getWebSocketService,
+};


### PR DESCRIPTION
## Summary
- fix `createApp` export
- fix default logger import
- re-export services correctly
- fix relative import extensions
- fix websocket service exports

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6852d8ee69088330960a03e474c58236